### PR TITLE
Stabilizing and improving anti-cheat ban handling

### DIFF
--- a/ac_s.lua
+++ b/ac_s.lua
@@ -35,6 +35,21 @@ Users = {}
 recentExplosions = {}
 recentEvents = {}
 
+function GetPlayerNeededIdentifiers(player)
+	local ids = GetPlayerIdentifiers(player)
+	for i,theIdentifier in ipairs(ids) do
+		if string.find(theIdentifier,"license:") or -1 > -1 then
+			license = theIdentifier
+		elseif string.find(theIdentifier,"steam:") or -1 > -1 then
+			steam = theIdentifier
+		end
+	end
+	if not steam then
+		steam = "steam: missing"
+	end
+	return license, steam
+end
+
 RegisterCommand("ac_scramble", function()
 	Citizen.CreateThread(function()
 		local clientScript = LoadResourceFile(GetCurrentResourceName(), "ac_c.lua")
@@ -345,21 +360,6 @@ function WarnPlayer(playerId, reason, banInstantly)
 end
 
 Citizen.CreateThread(function()
-	
-	function GetPlayerNeededIdentifiers(player)
-		local ids = GetPlayerIdentifiers(player)
-		for i,theIdentifier in ipairs(ids) do
-			if string.find(theIdentifier,"license:") or -1 > -1 then
-				license = theIdentifier
-			elseif string.find(theIdentifier,"steam:") or -1 > -1 then
-				steam = theIdentifier
-			end
-		end
-		if not steam then
-			steam = "steam: missing"
-		end
-		return license, steam
-	end
 	
 	RegisterServerEvent('AntiCheese:SpeedFlag')
 	AddEventHandler('AntiCheese:SpeedFlag', function(rounds, roundm)


### PR DESCRIPTION
## Summary
This PR includes two commits focused on stabilizing and improving anti-cheat ban handling in `ac_s.lua`.

## What changed

### 1) Move `GetPlayerNeededIdentifiers` to prevent nil function
- Moved `GetPlayerNeededIdentifiers(player)` out of the `Citizen.CreateThread` block.
- This ensures the function is defined earlier and available when needed, preventing nil-function runtime issues.
- Behavior remains the same: it extracts `license` and `steam` identifiers and falls back to `"steam: missing"` when needed.

### 2) Add ban management functions and refactor ban logic
- Added backend detection with `AC_GetBanBackend()` for:
  - EasyAdmin
  - BanSql
- Added command probing with `AC_HasCommand()` and txAdmin fallback flow with `AC_TryTxAdminBan()`.
- Added `AC_TakeScreenshot(playerId)` to route screenshot capture to the active backend.
- Added `AC_AddBan(playerId, reason)` to centralize ban actions with this priority:
  1. EasyAdmin event
  2. BanSql export 
  3. txAdmin commands (`txaBan` / `txaKick`)
  4. `DropPlayer` fallback
- Refactored `WarnPlayer()` to use the new centralized functions instead of hardcoded EasyAdmin events.

## Why
- Prevents nil reference issues caused by function scope/timing.
- Decouples anti-cheat punishment flow from a single ban resource.
- Improves compatibility across different server moderation stacks.
- Provides graceful fallbacks when a specific ban backend is unavailable.

## Impact
- File changed: `ac_s.lua`
- Expected result: more reliable ban/screenshot execution across EasyAdmin, BanSql, and txAdmin-enabled environments.
- No intended gameplay-facing behavior changes outside moderation/anti-cheat enforcement robustness.

## Commits included
- `7995ef9` — Move `GetPlayerNeededIdentifiers` function to prevent nil function
- `92d5472` — Add ban management functions and refactor ban logic